### PR TITLE
Close #125 compatibility with telnet

### DIFF
--- a/src/server_socket.cpp
+++ b/src/server_socket.cpp
@@ -76,7 +76,7 @@ std::string ClientSocket::readLine()
             throw ExceptionSocketClient(ExceptionSocketClientTypes::Reading, errno);
         }
         // if c is not \0
-        if (c != '\n')
+        if (c != '\r' && c != '\n')
         {
             // concatenate the character to the string
             s += c;


### PR DESCRIPTION
Ignoring \r when receiving is enough to communicate with default telnet client.