### PR TITLE
updated symbol name for HexaToDec

### DIFF
--- a/doc/html/pid_8h_source.html
+++ b/doc/html/pid_8h_source.html
@@ -845,7 +845,7 @@ $(function() {
 <div class="line"><a name="l00795"></a><span class="lineno">  795</span>&#160;    std::string data_bytes_; </div>
 <div class="line"><a name="l00800"></a><span class="lineno">  800</span>&#160;    <a class="code" href="class_pid.html">Pid</a>();</div>
 <div class="line"><a name="l00801"></a><span class="lineno">  801</span>&#160; </div>
-<div class="line"><a name="l00807"></a><span class="lineno">  807</span>&#160;    <span class="keywordtype">unsigned</span> <span class="keywordtype">int</span> HexaToDec(std::string data_bytes) <span class="keyword">const</span>;</div>
+<div class="line"><a name="l00807"></a><span class="lineno">  807</span>&#160;    <span class="keywordtype">unsigned</span> <span class="keywordtype">int</span> hexToDec(std::string data_bytes) <span class="keyword">const</span>;</div>
 <div class="line"><a name="l00808"></a><span class="lineno">  808</span>&#160; </div>
 <div class="line"><a name="l00809"></a><span class="lineno">  809</span>&#160;<span class="keyword">public</span>:</div>
 <div class="line"><a name="l00814"></a><span class="lineno">  814</span>&#160;    <a class="code" href="class_pid.html">Pid</a>(std::string pid);</div>

--- a/src/pid.cpp
+++ b/src/pid.cpp
@@ -6196,37 +6196,37 @@ unsigned int Pid::getDataByteAtIndex(unsigned int index) const
     {
         data.erase(0, 4);
         data.erase(2, data.size() - 2);
-        return HexaToDec(data);
+        return hexToDec(data);
     }
     else if (index == 1)
     {
         data.erase(0, 6);
         data.erase(2, data.size() - 2);
-        return HexaToDec(data);
+        return hexToDec(data);
     }
     else if (index == 2)
     {
         data.erase(0, 8);
         data.erase(2, data.size() - 2);
-        return HexaToDec(data);
+        return hexToDec(data);
     }
     else if (index == 3)
     {
         data.erase(0, 10);
         data.erase(2, data.size() - 2);
-        return HexaToDec(data);
+        return hexToDec(data);
     }
     else if (index == 4)
     {
         data.erase(0, 12);
         data.erase(2, data.size() - 2);
-        return HexaToDec(data);
+        return hexToDec(data);
     }
     else if (index == 5)
     {
         data.erase(0, 14);
         data.erase(2, data.size() - 2);
-        return HexaToDec(data);
+        return hexToDec(data);
     }
     else
     {
@@ -11927,7 +11927,7 @@ std::vector<float> Pid::getValue() const
         break;
     }
 }
- unsigned int Pid::HexaToDec(std::string data_bytes) const
+ unsigned int Pid::hexToDec(std::string data_bytes) const
  {
     std::istringstream nb(data_bytes);
 	unsigned int n;

--- a/src/pid.h
+++ b/src/pid.h
@@ -804,7 +804,7 @@ private:
      * \param data_bytes : Data bytes in hexadecimal format (as string)
      * \return decimal
      */
-    unsigned int HexaToDec(std::string data_bytes) const;
+    unsigned int hexToDec(std::string data_bytes) const;
 
 public:
     /*!


### PR DESCRIPTION
Attempts to fix #117 
Since the function changes data from base 16 to 10, 
the symbol name `hexToDec` seems more appropriate.